### PR TITLE
CommunityOwnable

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: |
   (?x)(
       ^build/|
-      ^reports/|
+      ^reports/
   )
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/README.md
+++ b/README.md
@@ -112,4 +112,3 @@ brownie run scripts/collectible/deploy.py --network rinkeby
 ```bash
 brownie run scripts/collectible/mint.py --network rinkeby
 ```
-

--- a/brownie-config.yaml
+++ b/brownie-config.yaml
@@ -27,6 +27,7 @@ reports:
         - ERC721
         - ERC721Enumerable
         - Strings
+        - contracts/mocks/**/*.*
 
 networks:
     default: development

--- a/contracts/CommunityOwnable.sol
+++ b/contracts/CommunityOwnable.sol
@@ -25,8 +25,8 @@ abstract contract CommunityOwnable is Context {
     /**
      * @dev Initializes the contract setting the deployer as the initial owner.
      */
-    constructor(address communityOwner) {
-        _transferCommunityOwnership(communityOwner);
+    constructor(address _communityOwner) {
+        _transferCommunityOwnership(_communityOwner);
     }
 
     /**

--- a/contracts/CommunityOwnable.sol
+++ b/contracts/CommunityOwnable.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT
+// Forked from OpenZeppelin Contracts v4.3.2 (access/Ownable.sol)
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/utils/Context.sol";
+
+/**
+ * @dev Contract module which provides a basic access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions.
+ *
+ * By default, the owner account will be the one that deploys the contract. This
+ * can later be changed with {transferOwnership}.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `onlyCommunityOwner`, which can be applied to your functions to restrict their use to
+ * the owner.
+ */
+abstract contract CommunityOwnable is Context {
+    address private _owner;
+
+    event CommunityOwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Initializes the contract setting the deployer as the initial owner.
+     */
+    constructor(address communityOwner) {
+        _transferCommunityOwnership(communityOwner);
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function communityOwner() public view virtual returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyCommunityOwner() {
+        require(owner() == _msgSender(), "CommunityOwnable: caller is not the community owner");
+        _;
+    }
+
+    /**
+     * @dev Leaves the contract without owner. It will not be possible to call
+     * `onlyCommunityOwner` functions anymore. Can only be called by the current owner.
+     *
+     * NOTE: Renouncing ownership will leave the contract without an owner,
+     * thereby removing any functionality that is only available to the owner.
+     */
+    function renounceCommunityOwnership() public virtual onlyCommunityOwner {
+        _transferOwnership(address(0));
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Can only be called by the current owner.
+     */
+    function transferCommunityOwnership(address newOwner) public virtual onlyCommunityOwner {
+        require(newOwner != address(0), "CommunityOwnable: new owner is the zero address");
+        _transferOwnership(newOwner);
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Internal function without access restriction.
+     */
+    function _transferCommunityOwnership(address newOwner) internal virtual {
+        address oldOwner = _owner;
+        _owner = newOwner;
+        emit CommunityOwnershipTransferred(oldOwner, newOwner);
+    }
+}

--- a/contracts/CommunityOwnable.sol
+++ b/contracts/CommunityOwnable.sol
@@ -40,7 +40,7 @@ abstract contract CommunityOwnable is Context {
      * @dev Throws if called by any account other than the owner.
      */
     modifier onlyCommunityOwner() {
-        require(owner() == _msgSender(), "CommunityOwnable: caller is not the community owner");
+        require(communityOwner() == _msgSender(), "CommunityOwnable: caller is not the community owner");
         _;
     }
 
@@ -52,7 +52,7 @@ abstract contract CommunityOwnable is Context {
      * thereby removing any functionality that is only available to the owner.
      */
     function renounceCommunityOwnership() public virtual onlyCommunityOwner {
-        _transferOwnership(address(0));
+        _transferCommunityOwnership(address(0));
     }
 
     /**
@@ -61,7 +61,7 @@ abstract contract CommunityOwnable is Context {
      */
     function transferCommunityOwnership(address newOwner) public virtual onlyCommunityOwner {
         require(newOwner != address(0), "CommunityOwnable: new owner is the zero address");
-        _transferOwnership(newOwner);
+        _transferCommunityOwnership(newOwner);
     }
 
     /**

--- a/contracts/WGMINFT.sol
+++ b/contracts/WGMINFT.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity >=0.7.0 <0.9.0;
 
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";

--- a/contracts/WGMINFT.sol
+++ b/contracts/WGMINFT.sol
@@ -3,7 +3,9 @@ pragma solidity >=0.7.0 <0.9.0;
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
-contract WGMINFT is ERC721Enumerable, Ownable {
+import "./CommunityOwnable.sol";
+
+contract WGMINFT is ERC721Enumerable, CommunityOwnable, Ownable {
     using Strings for uint256;
 
     string public baseURI;
@@ -23,8 +25,11 @@ contract WGMINFT is ERC721Enumerable, Ownable {
         string memory _name,
         string memory _symbol,
         string memory _initBaseURI,
-        string memory _initNotRevealedUri
-        ) ERC721(_name, _symbol) {
+        string memory _initNotRevealedUri,
+        address memory _communityOwner
+        )
+    ERC721(_name, _symbol)
+    CommunityOwnable(_communityOwner) {
         setBaseURI(_initBaseURI);
         setNotRevealedURI(_initNotRevealedUri);
     }

--- a/contracts/WGMINFT.sol
+++ b/contracts/WGMINFT.sol
@@ -26,7 +26,7 @@ contract WGMINFT is ERC721Enumerable, CommunityOwnable, Ownable {
         string memory _symbol,
         string memory _initBaseURI,
         string memory _initNotRevealedUri,
-        address memory _communityOwner
+        address _communityOwner
         )
     ERC721(_name, _symbol)
     CommunityOwnable(_communityOwner) {

--- a/contracts/mocks/CommunityOwnableMock.sol
+++ b/contracts/mocks/CommunityOwnableMock.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity >=0.7.0 <0.9.0;
+
+import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+import "../CommunityOwnable.sol";
+
+contract CommunityOwnableMock is CommunityOwnable {
+    using Strings for uint256;
+
+    constructor(address _communityOwner)
+    CommunityOwnable(_communityOwner) {
+    }
+
+
+    function testOnlyCommunityOwnerModifier() public onlyCommunityOwner {
+    }
+}

--- a/scripts/collectible/deploy.py
+++ b/scripts/collectible/deploy.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 import os
-from brownie import WGMINFT, accounts, network, config
+
+from brownie import WGMINFT, accounts, config, network
 
 # Constructor Config
 NFT_NAME = "WGMINFT Name"

--- a/scripts/collectible/get_verification_output.py
+++ b/scripts/collectible/get_verification_output.py
@@ -1,14 +1,11 @@
 #!/usr/bin/python3
-import os
-from brownie import WGMINFT, accounts, network, config
+
+from brownie import WGMINFT, network
 
 
 def main():
-    dev = accounts.add(config["wallets"]["from_key"])
     print(network.show_active())
-    publish_source = True if os.getenv("ETHERSCAN_TOKEN") else False
 
     verification_info = WGMINFT.get_verification_info()
 
-    # print("verification_info: ", verification_info)
-    print("\nflattened_source: ", verification_info)
+    print("verification_info: ", verification_info)

--- a/scripts/collectible/mint.py
+++ b/scripts/collectible/mint.py
@@ -1,6 +1,8 @@
 #!/usr/bin/python3
 import os
-from brownie import WGMINFT, accounts, network, config
+
+from brownie import WGMINFT, accounts, network
+
 from scripts.helpful_scripts import OPENSEA_FORMAT
 
 

--- a/scripts/collectible/unpause.py
+++ b/scripts/collectible/unpause.py
@@ -1,12 +1,11 @@
 #!/usr/bin/python3
-from brownie import WGMINFT, accounts, network, config
-from scripts.helpful_scripts import OPENSEA_FORMAT
+from brownie import WGMINFT, accounts, config, network
 
 
 def main():
     CREATOR_PRIVATE_KEY = accounts.add(config["wallets"]["from_key"])
     print(network.show_active())
-    contract = token = WGMINFT.at("0x78C4864f49a6Ac8104491789BFcF3cC04a19E23c")
+    contract = WGMINFT.at("0x78C4864f49a6Ac8104491789BFcF3cC04a19E23c")
 
     transaction = contract.setPause(False, {"from": CREATOR_PRIVATE_KEY})
 

--- a/scripts/collectible/verify.py
+++ b/scripts/collectible/verify.py
@@ -1,11 +1,10 @@
 #!/usr/bin/python3
-import os, sys
-from brownie import WGMINFT, accounts, network, config
+
+import os
+
+from brownie import WGMINFT
 
 
 def main():
-    dev = accounts.add(config["wallets"]["from_key"])
-    print("Current network:", network.show_active())
-
     token = WGMINFT.at(os.getenv("ADDRESS_TO_VERIFY"))
     WGMINFT.publish_source(token)

--- a/scripts/collectible/withdraw_all.py
+++ b/scripts/collectible/withdraw_all.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python3
-from brownie import WGMINFT, accounts, network, config
-from scripts.helpful_scripts import OPENSEA_FORMAT
+from brownie import WGMINFT, accounts, config, network
 
 
 def main():

--- a/scripts/flatten.py
+++ b/scripts/flatten.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
-from brownie import WGMINFT, accounts, network, config, interface
 import json
+
+from brownie import WGMINFT
 
 
 def main():

--- a/scripts/helpful_scripts.py
+++ b/scripts/helpful_scripts.py
@@ -1,11 +1,4 @@
-from brownie import (
-    network,
-    accounts,
-    config,
-    interface,
-    Contract,
-)
-
+from brownie import accounts, config, network
 
 OPENSEA_FORMAT = "https://testnets.opensea.io/assets/{}/{}"
 NON_FORKED_LOCAL_BLOCKCHAIN_ENVIRONMENTS = ["hardhat", "development", "ganache"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,7 @@
 import pytest
-from brownie import (
-    accounts,
-    config,
-    network,
-)
-from scripts.helpful_scripts import (
-    LOCAL_BLOCKCHAIN_ENVIRONMENTS,
-)
+from brownie import accounts, config, network
+
+from scripts.helpful_scripts import LOCAL_BLOCKCHAIN_ENVIRONMENTS
 
 
 @pytest.fixture

--- a/tests/e2e/test_mint.py
+++ b/tests/e2e/test_mint.py
@@ -18,6 +18,7 @@ class TestNonWhitelistMinting:
         self.owner = get_account()
         self.non_owner = get_account(index=2)
         self.non_owner_2 = get_account(index=3)
+        self.community_owner = get_account(index=4)
 
         # Deploy, disable onlyWhitelisted, and unpause
         self.collectible = WGMINFT.deploy(
@@ -25,6 +26,7 @@ class TestNonWhitelistMinting:
             "MCN",
             "INITIAL_BASE_URI",
             "INITIAL_NOT_REVEALED_URI",
+            self.community_owner,
             {"from": self.owner},
         )
         self.collectible.setOnlyWhitelisted(False, {"from": self.owner})
@@ -175,6 +177,7 @@ class TestWhitelistMinting:
         self.owner = get_account()
         self.non_owner = get_account(index=2)
         self.non_owner_2 = get_account(index=3)
+        self.community_owner = get_account(index=4)
 
         # Deploy, and unpause
         self.collectible = WGMINFT.deploy(
@@ -182,6 +185,7 @@ class TestWhitelistMinting:
             "MCN",
             "INITIAL_BASE_URI",
             "INITIAL_NOT_REVEALED_URI",
+            self.community_owner,
             {"from": self.owner},
         )
         self.collectible.pause(False, {"from": self.owner})

--- a/tests/e2e/test_pause.py
+++ b/tests/e2e/test_pause.py
@@ -15,6 +15,7 @@ class TestPause:
 
         self.owner = get_account()
         self.non_owner = get_account(index=2)
+        self.community_owner = get_account(index=4)
 
         # Deploy and disable onlyWhitelisted
         self.collectible = WGMINFT.deploy(
@@ -22,6 +23,7 @@ class TestPause:
             "MCN",
             "INITIAL_BASE_URI",
             "INITIAL_NOT_REVEALED_URI",
+            self.community_owner,
             {"from": self.owner},
         )
         self.collectible.setOnlyWhitelisted(False, {"from": self.owner})

--- a/tests/e2e/test_token_uri.py
+++ b/tests/e2e/test_token_uri.py
@@ -18,6 +18,7 @@ class TestTokenUri:
         self.owner = get_account()
         self.non_owner = get_account(index=2)
         self.ORIGINAL_OWNER_BALANCE = self.owner.balance()
+        self.community_owner = get_account(index=4)
 
         # Deploy
         self.collectible = WGMINFT.deploy(
@@ -25,6 +26,7 @@ class TestTokenUri:
             "MCN",
             "initial_base_uri_example/",
             "initial_not_revealed_uri_example/",
+            self.community_owner,
             {"from": self.owner},
         )
         self.collectible.pause(False, {"from": self.owner})

--- a/tests/e2e/test_withdraw.py
+++ b/tests/e2e/test_withdraw.py
@@ -20,6 +20,7 @@ class TestWithdrawal:
         self.owner = get_account()
         self.non_owner = get_account(index=2)
         self.ORIGINAL_OWNER_BALANCE = self.owner.balance()
+        self.community_owner = get_account(index=4)
 
         # Deploy and disable onlyWhitelisted
         self.collectible = WGMINFT.deploy(
@@ -27,6 +28,7 @@ class TestWithdrawal:
             "MCN",
             "INITIAL_BASE_URI",
             "INITIAL_NOT_REVEALED_URI",
+            self.community_owner,
             {"from": self.owner},
         )
         self.collectible.setOnlyWhitelisted(False, {"from": self.owner})

--- a/tests/unit/test_community_ownable.py
+++ b/tests/unit/test_community_ownable.py
@@ -1,0 +1,31 @@
+import pytest
+from brownie import CommunityOwnableMock, network, reverts
+
+from scripts.helpful_scripts import get_account
+
+
+class TestCommunityOwnable:
+    def setup(self):
+        """
+        Deploy contract
+        """
+
+        if network.show_active() not in ["development"] or "fork" in network.show_active():
+            pytest.skip("Only for local testing")
+
+        self.owner = get_account()
+        self.non_owner = get_account(index=1)
+        self.community_owner = get_account(index=2)
+
+        # Deploy
+        self.collectible = CommunityOwnableMock.deploy(
+            self.community_owner,
+            {"from": self.owner},
+        )
+
+    def test_onlyCommunityOwnerModifier(self):
+        # with pytest.raises(reverts("XXX")):
+        self.collectible.testOnlyCommunityOwnerModifier({"from": self.community_owner})
+
+        with reverts("CommunityOwnable: caller is not the community owner"):
+            self.collectible.testOnlyCommunityOwnerModifier({"from": self.owner})

--- a/tests/unit/test_public_methods.py
+++ b/tests/unit/test_public_methods.py
@@ -33,6 +33,7 @@ class TestPublicMethods:
 
         self.owner = get_account()
         self.non_owner = get_account(index=2)
+        self.community_owner = get_account(index=4)
 
         # Deploy
         self.collectible = WGMINFT.deploy(
@@ -40,6 +41,7 @@ class TestPublicMethods:
             "MCN",
             "my_initial_base_uri",
             "my_initial_not_revealed_uri",
+            self.community_owner,
             {"from": self.owner},
         )
 


### PR DESCRIPTION
Create CommunityOwnable contract, and base WGMI on it.
Fix tests with new constructor.

This allows us to restrict actions to the community wallet: fixes issue #3 

Still need to restrict public methods with onlyCommunityWallet modifier (issue #4).

# TODOS

- [x] Add tests 
