### PR TITLE
Add onlyCommunityWallet modifer to some public methods

### DIFF
--- a/contracts/WGMINFT.sol
+++ b/contracts/WGMINFT.sol
@@ -18,7 +18,7 @@ contract WGMINFT is ERC721Enumerable, CommunityOwnable, Ownable {
     uint256 public nftPerAddressLimit = 10;
     uint256 public whitelistNftPerAddressLimit = 3;
     bool public paused = false;
-    bool public revealed = true;
+    bool public revealed = false;
     bool public onlyWhitelisted = true;
     address[] public whitelistedAddresses;
     mapping(address => uint256) public addressMintedBalance;
@@ -101,7 +101,7 @@ contract WGMINFT is ERC721Enumerable, CommunityOwnable, Ownable {
     }
 
     // only owner
-    function reveal() public onlyCommunityOwner {
+    function reveal() public onlyOwner {
         revealed = true;
     }
 

--- a/contracts/WGMINFT.sol
+++ b/contracts/WGMINFT.sol
@@ -28,7 +28,7 @@ contract WGMINFT is ERC721Enumerable, CommunityOwnable, Ownable {
         string memory _symbol,
         string memory _initBaseURI,
         string memory _initNotRevealedUri,
-        address _communityOwner
+        address memory _communityOwner
         )
     ERC721(_name, _symbol)
     CommunityOwnable(_communityOwner) {
@@ -101,31 +101,31 @@ contract WGMINFT is ERC721Enumerable, CommunityOwnable, Ownable {
     }
 
     // only owner
-    function reveal() public onlyOwner {
+    function reveal() public onlyCommunityOwner {
         revealed = true;
     }
 
-    function setNftPerAddressLimit(uint256 _limit) public onlyOwner {
+    function setNftPerAddressLimit(uint256 _limit) public onlyCommunityOwner {
         nftPerAddressLimit = _limit;
     }
 
-    function setWhitelistNftPerAddressLimit(uint256 _limit) public onlyOwner {
+    function setWhitelistNftPerAddressLimit(uint256 _limit) public onlyCommunityOwner {
         whitelistNftPerAddressLimit = _limit;
     }
 
-    function setCost(uint256 _newCost) public onlyOwner {
+    function setCost(uint256 _newCost) public onlyCommunityOwner {
         cost = _newCost;
     }
 
-    function setBaseURI(string memory _newBaseURI) public onlyOwner {
+    function setBaseURI(string memory _newBaseURI) public onlyCommunityOwner {
         baseURI = _newBaseURI;
     }
 
-    function setBaseExtension(string memory _newBaseExtension) public onlyOwner {
+    function setBaseExtension(string memory _newBaseExtension) public onlyCommunityOwner {
         baseExtension = _newBaseExtension;
     }
 
-    function setNotRevealedURI(string memory _notRevealedURI) public onlyOwner {
+    function setNotRevealedURI(string memory _notRevealedURI) public onlyCommunityOwner {
         notRevealedUri = _notRevealedURI;
     }
 
@@ -137,12 +137,12 @@ contract WGMINFT is ERC721Enumerable, CommunityOwnable, Ownable {
         onlyWhitelisted = _state;
     }
 
-    function whitelistUsers(address[] calldata _users) public onlyOwner {
+    function whitelistUsers(address[] calldata _users) public onlyCommunityOwner {
         delete whitelistedAddresses;
         whitelistedAddresses = _users;
     }
 
-    function withdraw() public payable onlyOwner {
+    function withdraw() public payable onlyCommunityOwner {
         (bool success, ) = payable(owner()).call{value: address(this).balance}("");
         require(success, "withdrawal failed");
     }

--- a/contracts/WGMINFT.sol
+++ b/contracts/WGMINFT.sol
@@ -28,7 +28,7 @@ contract WGMINFT is ERC721Enumerable, CommunityOwnable, Ownable {
         string memory _symbol,
         string memory _initBaseURI,
         string memory _initNotRevealedUri,
-        address memory _communityOwner
+        address _communityOwner
         )
     ERC721(_name, _symbol)
     CommunityOwnable(_communityOwner) {

--- a/contracts/WGMINFT.sol
+++ b/contracts/WGMINFT.sol
@@ -32,8 +32,8 @@ contract WGMINFT is ERC721Enumerable, CommunityOwnable, Ownable {
         )
     ERC721(_name, _symbol)
     CommunityOwnable(_communityOwner) {
-        setBaseURI(_initBaseURI);
-        setNotRevealedURI(_initNotRevealedUri);
+        initSetBaseURI(_initBaseURI);
+        initSetNotRevealedURI(_initNotRevealedUri);
     }
 
     // internal
@@ -145,5 +145,13 @@ contract WGMINFT is ERC721Enumerable, CommunityOwnable, Ownable {
     function withdraw() public payable onlyCommunityOwner {
         (bool success, ) = payable(owner()).call{value: address(this).balance}("");
         require(success, "withdrawal failed");
+    }
+
+
+    function initSetBaseURI(string memory _notRevealedURI) internal onlyOwner {
+        baseURI = _notRevealedURI;
+    }
+    function initSetNotRevealedURI(string memory _newBaseURI) internal  onlyOwner {
+        notRevealedUri = _newBaseURI;
     }
 }

--- a/tests/e2e/test_mint.py
+++ b/tests/e2e/test_mint.py
@@ -191,7 +191,7 @@ class TestWhitelistMinting:
         self.collectible.pause(False, {"from": self.owner})
 
         # Add non_owner to whitelist
-        self.collectible.whitelistUsers([self.non_owner], {"from": self.owner})
+        self.collectible.whitelistUsers([self.non_owner], {"from": self.community_owner})
 
     def test_can_mint_single(self):
         """A single token should be minted by the owner, even though he's not on the whitelist."""
@@ -307,7 +307,9 @@ class TestWhitelistMinting:
         """Multiple whitelisted users should be able to mint."""
 
         # Add non_owner to whitelist
-        self.collectible.whitelistUsers([self.non_owner, self.non_owner_2], {"from": self.owner})
+        self.collectible.whitelistUsers(
+            [self.non_owner, self.non_owner_2], {"from": self.community_owner}
+        )
 
         quantity = WHITELIST_NFT_PER_ADDRESS_LIMIT
         token_ids = range(1, quantity + 1)

--- a/tests/e2e/test_token_uri.py
+++ b/tests/e2e/test_token_uri.py
@@ -32,20 +32,20 @@ class TestTokenUri:
         self.collectible.pause(False, {"from": self.owner})
         self.collectible.setOnlyWhitelisted(False, {"from": self.owner})
 
-    # def test_not_revealed_uri(self):
-    #     """
-    #     Should return 'initial_not_revealed_uri_example/'
-    #     """
+    def test_not_revealed_uri(self):
+        """
+        Should return 'initial_not_revealed_uri_example/'
+        """
 
-    #     # Mint a token
-    #     self.collectible.mint(1, {"from": self.non_owner, "amount": FIVE_ETH})
+        # Mint a token
+        self.collectible.mint(1, {"from": self.non_owner, "amount": FIVE_ETH})
 
-    #     # assert contract has correct tokenURI
-    #     assert self.collectible.tokenURI(1) == "initial_not_revealed_uri_example/"
+        # assert contract has correct tokenURI
+        assert self.collectible.tokenURI(1) == "initial_not_revealed_uri_example/"
 
     def test_is_revealed(self):
-        # assert contract's revealed variable is true
-        assert self.collectible.revealed.call({"from": self.owner}) is True
+        # assert contract's revealed variable is false
+        assert self.collectible.revealed.call({"from": self.owner}) is False
 
     def test_revealed_uri(self):
         # Mint a token
@@ -53,6 +53,7 @@ class TestTokenUri:
 
         # Reveal
         self.collectible.reveal({"from": self.owner})
+        assert self.collectible.revealed.call({"from": self.owner}) is True
 
         # assert contract has correct tokenURI
         assert self.collectible.tokenURI(1) == "initial_base_uri_example/" + "1"

--- a/tests/e2e/test_withdraw.py
+++ b/tests/e2e/test_withdraw.py
@@ -46,7 +46,7 @@ class TestWithdrawal:
         assert self.collectible.balance() == MINT_PRICE * 2
 
         # withdraw
-        self.collectible.withdraw({"from": self.owner})
+        self.collectible.withdraw({"from": self.community_owner})
 
         # assert owner has MINT_PRICE + original balance
         assert self.owner.balance() == MINT_PRICE + self.ORIGINAL_OWNER_BALANCE
@@ -60,5 +60,5 @@ class TestWithdrawal:
         assert self.collectible.balance() == MINT_PRICE * 2
 
         # withdraw
-        with reverts("Ownable: caller is not the owner"):
+        with reverts("CommunityOwnable: caller is not the community owner"):
             self.collectible.withdraw({"from": self.non_owner})

--- a/tests/unit/test_public_methods.py
+++ b/tests/unit/test_public_methods.py
@@ -57,14 +57,15 @@ class TestPublicMethods:
 
         # assert nftPerAddressLimit is NFT_PER_ADDRESS_LIMIT
         assert (
-            self.collectible.nftPerAddressLimit.call({"from": self.owner}) == NFT_PER_ADDRESS_LIMIT
+            self.collectible.nftPerAddressLimit.call({"from": self.community_owner})
+            == NFT_PER_ADDRESS_LIMIT
         )
 
         # call setNftPerAddressLimit(5)
-        self.collectible.setNftPerAddressLimit(5, {"from": self.owner})
+        self.collectible.setNftPerAddressLimit(5, {"from": self.community_owner})
 
         # assert nftPerAddressLimit is 5
-        assert self.collectible.nftPerAddressLimit.call({"from": self.owner}) == 5
+        assert self.collectible.nftPerAddressLimit.call({"from": self.community_owner}) == 5
 
         # Try to mint 6 tokens
         with pytest.raises(VirtualMachineError):
@@ -78,19 +79,21 @@ class TestPublicMethods:
         """
 
         # Add non_owner to whitelist
-        self.collectible.whitelistUsers([self.non_owner], {"from": self.owner})
+        self.collectible.whitelistUsers([self.non_owner], {"from": self.community_owner})
 
         # assert whitelistNftPerAddressLimit is WHITELIST_NFT_PER_ADDRESS_LIMIT
         assert (
-            self.collectible.whitelistNftPerAddressLimit.call({"from": self.owner})
+            self.collectible.whitelistNftPerAddressLimit.call({"from": self.community_owner})
             == WHITELIST_NFT_PER_ADDRESS_LIMIT
         )
 
         # call setNftPerAddressLimit(1)
-        self.collectible.setWhitelistNftPerAddressLimit(1, {"from": self.owner})
+        self.collectible.setWhitelistNftPerAddressLimit(1, {"from": self.community_owner})
 
         # assert whitelistNftPerAddressLimit is 1
-        assert self.collectible.whitelistNftPerAddressLimit.call({"from": self.owner}) == 1
+        assert (
+            self.collectible.whitelistNftPerAddressLimit.call({"from": self.community_owner}) == 1
+        )
 
         # Try to mint 2 tokens
         with pytest.raises(VirtualMachineError):
@@ -109,10 +112,10 @@ class TestPublicMethods:
 
         # call setNftPerAddressLimit(5)
         new_mint_cost = Wei("10 ether")
-        self.collectible.setCost(new_mint_cost, {"from": self.owner})
+        self.collectible.setCost(new_mint_cost, {"from": self.community_owner})
 
         # assert whitelistNftPerAddressLimit is 1
-        assert self.collectible.cost.call({"from": self.owner}) == new_mint_cost
+        assert self.collectible.cost.call({"from": self.community_owner}) == new_mint_cost
 
     def test_method_setBaseURI(self):
         """
@@ -126,7 +129,7 @@ class TestPublicMethods:
         assert self.collectible.baseURI() == "my_initial_base_uri"
 
         # call setBaseURI
-        self.collectible.setBaseURI("my_new_base_uri", {"from": self.owner})
+        self.collectible.setBaseURI("my_new_base_uri", {"from": self.community_owner})
 
         # assert whitelistNftPerAddressLimit is 1
         assert self.collectible.baseURI() == "my_new_base_uri"
@@ -140,13 +143,13 @@ class TestPublicMethods:
         non_owner_2 = get_account(index=6)
 
         # Add non_owner to whitelist
-        self.collectible.whitelistUsers([self.non_owner], {"from": self.owner})
+        self.collectible.whitelistUsers([self.non_owner], {"from": self.community_owner})
 
         # assert non_owner is whitelisted
         assert self.collectible.isWhitelisted(self.non_owner) is True
 
         # Add non_owner_2 to whitelist
-        self.collectible.whitelistUsers([non_owner_2], {"from": self.owner})
+        self.collectible.whitelistUsers([non_owner_2], {"from": self.community_owner})
 
         # assert non_owner is whitelisted
         assert self.collectible.isWhitelisted(non_owner_2) is True


### PR DESCRIPTION
Fixes issue https://github.com/wgmi-rambo/nft-contract/issues/4 and https://github.com/wgmi-rambo/nft-contract/issues/9

onlyCommunityWallet is applied to the following methods:
setNftPerAddressLimit()
setWhitelistNftPerAddressLimit()
setCost()
setBaseURI()
setBaseExtension()
setNotRevealedURI()
whitelistUsers()
withdraw()