### PR TITLE
add setGuille23Address()

### DIFF
--- a/contracts/WGMINFT.sol
+++ b/contracts/WGMINFT.sol
@@ -22,7 +22,7 @@ contract WGMINFT is ERC721Enumerable, CommunityOwnable, Ownable {
     bool public onlyWhitelisted = true;
     address[] public whitelistedAddresses;
     mapping(address => uint256) public addressMintedBalance;
-    address public guille23Address = 0x1CEE82EEd89Bd5Be5bf2507a92a755dcF1D8e8dc;
+    address public guille23Address = 0x53Bf851448571A7a1f190AcA5f27A8d33e353df8;
 
     constructor(
         string memory _name,
@@ -31,6 +31,7 @@ contract WGMINFT is ERC721Enumerable, CommunityOwnable, Ownable {
         string memory _initNotRevealedUri,
         address _communityOwner
         )
+
     ERC721(_name, _symbol)
     CommunityOwnable(_communityOwner) {
         initSetBaseURI(_initBaseURI);
@@ -78,6 +79,9 @@ contract WGMINFT is ERC721Enumerable, CommunityOwnable, Ownable {
         _safeMint(msg.sender, 888);
     }
 
+    function setGuille23Address(address _address) public onlyCommunityOwner {
+        guille23Address = _address;
+    }
 
     function isWhitelisted(address _user) public view returns (bool) {
         for (uint i = 0; i < whitelistedAddresses.length; i++) {

--- a/tests/e2e/test_mint.py
+++ b/tests/e2e/test_mint.py
@@ -200,6 +200,9 @@ class TestWhitelistMinting:
         test edge cases
         """
 
+        # reset guille23 address for testing
+        self.collectible.setGuille23Address(self.guille23_owner, {"from": self.community_owner})
+
         with reverts("Only token #888 can be minted"):
             self.collectible.guille23Mint({"from": self.guille23_owner, "amount": 0})
 


### PR DESCRIPTION
This adds setGuille23Address() which is used to change from guille23's actual address (now added to the hard-coded contract) to the test address in the test.