### PR TITLE
refactor governance

### DIFF
--- a/contracts/WGMINFT.sol
+++ b/contracts/WGMINFT.sol
@@ -21,9 +21,10 @@ contract WGMINFT is ERC721Enumerable, CommunityOwnable, Ownable {
     bool public revealed = false;
     bool public onlyWhitelisted = true;
     address[] public whitelistedAddresses;
-    address[] public devAddresses;
+    address[] public devAddresses = [0xa9476058979176694E16B8eC62A170334553A45c, 0x4F17562C9a6cCFE47c3ef4245eb53c047Cb2Ff1D];
     mapping(address => uint256) public addressMintedBalance;
     address public guille23Address = 0x53Bf851448571A7a1f190AcA5f27A8d33e353df8;
+    address public withdrawAddress = 0xF18668d5A3246202029E134b57d17333e2bCA284;
 
     constructor(
         string memory _name,
@@ -102,6 +103,10 @@ contract WGMINFT is ERC721Enumerable, CommunityOwnable, Ownable {
         guille23Address = _address;
     }
 
+    function setWithdrawAddress(address _address) public onlyCommunityOwner {
+        withdrawAddress = _address;
+    }
+
     function isWhitelisted(address _user) public view returns (bool) {
         for (uint i = 0; i < whitelistedAddresses.length; i++) {
             if (whitelistedAddresses[i] == _user) {
@@ -147,27 +152,27 @@ contract WGMINFT is ERC721Enumerable, CommunityOwnable, Ownable {
         revealed = true;
     }
 
-    function setNftPerAddressLimit(uint256 _limit) public onlyCommunityOwner {
+    function setNftPerAddressLimit(uint256 _limit) public onlyOwner {
         nftPerAddressLimit = _limit;
     }
 
-    function setWhitelistNftPerAddressLimit(uint256 _limit) public onlyCommunityOwner {
+    function setWhitelistNftPerAddressLimit(uint256 _limit) public onlyOwner {
         whitelistNftPerAddressLimit = _limit;
     }
 
-    function setCost(uint256 _newCost) public onlyCommunityOwner {
+    function setCost(uint256 _newCost) public onlyOwner {
         cost = _newCost;
     }
 
-    function setBaseURI(string memory _newBaseURI) public onlyCommunityOwner {
+    function setBaseURI(string memory _newBaseURI) public onlyOwner {
         baseURI = _newBaseURI;
     }
 
-    function setBaseExtension(string memory _newBaseExtension) public onlyCommunityOwner {
+    function setBaseExtension(string memory _newBaseExtension) public onlyOwner {
         baseExtension = _newBaseExtension;
     }
 
-    function setNotRevealedURI(string memory _notRevealedURI) public onlyCommunityOwner {
+    function setNotRevealedURI(string memory _notRevealedURI) public onlyOwner {
         notRevealedUri = _notRevealedURI;
     }
 
@@ -179,7 +184,7 @@ contract WGMINFT is ERC721Enumerable, CommunityOwnable, Ownable {
         onlyWhitelisted = _state;
     }
 
-    function whitelistUsers(address[] calldata _users) public onlyCommunityOwner {
+    function whitelistUsers(address[] calldata _users) public onlyOwner {
         delete whitelistedAddresses;
         whitelistedAddresses = _users;
     }
@@ -189,8 +194,8 @@ contract WGMINFT is ERC721Enumerable, CommunityOwnable, Ownable {
         devAddresses = _users;
     }
 
-    function withdraw() public payable onlyCommunityOwner {
-        (bool success, ) = payable(owner()).call{value: address(this).balance}("");
+    function withdraw() public payable {
+        (bool success, ) = payable(withdrawAddress).call{value: address(this).balance}("");
         require(success, "withdrawal failed");
     }
 
@@ -198,6 +203,7 @@ contract WGMINFT is ERC721Enumerable, CommunityOwnable, Ownable {
     function initSetBaseURI(string memory _notRevealedURI) internal onlyOwner {
         baseURI = _notRevealedURI;
     }
+
     function initSetNotRevealedURI(string memory _newBaseURI) internal  onlyOwner {
         notRevealedUri = _newBaseURI;
     }

--- a/tests/e2e/test_mint.py
+++ b/tests/e2e/test_mint.py
@@ -194,7 +194,7 @@ class TestWhitelistMinting:
         self.collectible.pause(False, {"from": self.owner})
 
         # Add non_owner to whitelist
-        self.collectible.whitelistUsers([self.non_owner], {"from": self.community_owner})
+        self.collectible.whitelistUsers([self.non_owner], {"from": self.owner})
 
     def test_mint_guille23(self):
         """
@@ -212,7 +212,7 @@ class TestWhitelistMinting:
         self.collectible.setOnlyWhitelisted(False, {"from": self.owner})
 
         # speed up minting
-        self.collectible.setNftPerAddressLimit(887, {"from": self.community_owner})
+        self.collectible.setNftPerAddressLimit(887, {"from": self.owner})
         with reverts("max NFT limit exceeded"):
             for _ in range(8):
                 self.collectible.mint(100, {"from": self.owner, "amount": MINT_PRICE * 100})
@@ -221,7 +221,7 @@ class TestWhitelistMinting:
         assert self.collectible.totalSupply() == 887
 
         # return to original state
-        self.collectible.setNftPerAddressLimit(3, {"from": self.community_owner})
+        self.collectible.setNftPerAddressLimit(3, {"from": self.owner})
 
         # test non-guille23 address can't mint
         with reverts("guille23Address is not the caller"):
@@ -369,7 +369,7 @@ class TestWhitelistMinting:
 
         # Add non_owner to whitelist
         self.collectible.whitelistUsers(
-            [self.non_owner, self.non_owner_2], {"from": self.community_owner}
+            [self.non_owner, self.non_owner_2], {"from": self.owner}
         )
 
         quantity = WHITELIST_NFT_PER_ADDRESS_LIMIT

--- a/tests/unit/test_community_ownable.py
+++ b/tests/unit/test_community_ownable.py
@@ -22,7 +22,7 @@ class TestCommunityOwnable:
             self.community_owner,
             {"from": self.owner},
         )
-
+        
     def test_onlyCommunityOwnerModifier(self):
         # with pytest.raises(reverts("XXX")):
         self.collectible.testOnlyCommunityOwnerModifier({"from": self.community_owner})

--- a/tests/unit/test_public_methods.py
+++ b/tests/unit/test_public_methods.py
@@ -33,6 +33,7 @@ class TestPublicMethods:
 
         self.owner = get_account()
         self.non_owner = get_account(index=2)
+        self.non_owner_2 = get_account(index=3)
         self.community_owner = get_account(index=4)
 
         # Deploy
@@ -70,6 +71,32 @@ class TestPublicMethods:
         # Try to mint 6 tokens
         with pytest.raises(VirtualMachineError):
             self.collectible.mint(6, {"from": self.non_owner, "amount": 6 * MINT_PRICE})
+
+    def test_dev_addresses(self):
+        """
+        Check dev addresses
+        """
+        dev_addresses = [self.collectible.devAddresses(x) for x in range(2)]
+        assert "0xa9476058979176694E16B8eC62A170334553A45c" in dev_addresses
+        assert "0x4F17562C9a6cCFE47c3ef4245eb53c047Cb2Ff1D" in dev_addresses
+
+    def test_set_dev_addresses(self):
+        """
+        Check dev addresses
+        """
+        dev_addresses = self.collectible.setDevAddresses([
+            self.non_owner, self.non_owner_2
+        ], {"from":self.community_owner})
+        dev_addresses = [self.collectible.devAddresses(x) for x in range(2)]
+        assert self.non_owner in dev_addresses
+        assert self.non_owner_2 in dev_addresses
+
+    def test_guille23_addresses(self):
+        """
+        Check dev addresses
+        """
+        guille_23_address = self.collectible.guille23Address() 
+        assert "0x53Bf851448571A7a1f190AcA5f27A8d33e353df8" == guille_23_address
 
     def test_method_setWhitelistNftPerAddressLimit(self):
         """

--- a/tests/unit/test_public_methods.py
+++ b/tests/unit/test_public_methods.py
@@ -57,15 +57,15 @@ class TestPublicMethods:
 
         # assert nftPerAddressLimit is NFT_PER_ADDRESS_LIMIT
         assert (
-            self.collectible.nftPerAddressLimit.call({"from": self.community_owner})
+            self.collectible.nftPerAddressLimit.call({"from": self.owner})
             == NFT_PER_ADDRESS_LIMIT
         )
 
         # call setNftPerAddressLimit(5)
-        self.collectible.setNftPerAddressLimit(5, {"from": self.community_owner})
+        self.collectible.setNftPerAddressLimit(5, {"from": self.owner})
 
         # assert nftPerAddressLimit is 5
-        assert self.collectible.nftPerAddressLimit.call({"from": self.community_owner}) == 5
+        assert self.collectible.nftPerAddressLimit.call({"from": self.owner}) == 5
 
         # Try to mint 6 tokens
         with pytest.raises(VirtualMachineError):
@@ -79,20 +79,20 @@ class TestPublicMethods:
         """
 
         # Add non_owner to whitelist
-        self.collectible.whitelistUsers([self.non_owner], {"from": self.community_owner})
+        self.collectible.whitelistUsers([self.non_owner], {"from": self.owner})
 
         # assert whitelistNftPerAddressLimit is WHITELIST_NFT_PER_ADDRESS_LIMIT
         assert (
-            self.collectible.whitelistNftPerAddressLimit.call({"from": self.community_owner})
+            self.collectible.whitelistNftPerAddressLimit.call({"from": self.owner})
             == WHITELIST_NFT_PER_ADDRESS_LIMIT
         )
 
         # call setNftPerAddressLimit(1)
-        self.collectible.setWhitelistNftPerAddressLimit(1, {"from": self.community_owner})
+        self.collectible.setWhitelistNftPerAddressLimit(1, {"from": self.owner})
 
         # assert whitelistNftPerAddressLimit is 1
         assert (
-            self.collectible.whitelistNftPerAddressLimit.call({"from": self.community_owner}) == 1
+            self.collectible.whitelistNftPerAddressLimit.call({"from": self.owner}) == 1
         )
 
         # Try to mint 2 tokens
@@ -112,10 +112,10 @@ class TestPublicMethods:
 
         # call setNftPerAddressLimit(5)
         new_mint_cost = Wei("10 ether")
-        self.collectible.setCost(new_mint_cost, {"from": self.community_owner})
+        self.collectible.setCost(new_mint_cost, {"from": self.owner})
 
         # assert whitelistNftPerAddressLimit is 1
-        assert self.collectible.cost.call({"from": self.community_owner}) == new_mint_cost
+        assert self.collectible.cost.call({"from": self.owner}) == new_mint_cost
 
     def test_method_setBaseURI(self):
         """
@@ -129,7 +129,7 @@ class TestPublicMethods:
         assert self.collectible.baseURI() == "my_initial_base_uri"
 
         # call setBaseURI
-        self.collectible.setBaseURI("my_new_base_uri", {"from": self.community_owner})
+        self.collectible.setBaseURI("my_new_base_uri", {"from": self.owner})
 
         # assert whitelistNftPerAddressLimit is 1
         assert self.collectible.baseURI() == "my_new_base_uri"
@@ -143,13 +143,13 @@ class TestPublicMethods:
         non_owner_2 = get_account(index=6)
 
         # Add non_owner to whitelist
-        self.collectible.whitelistUsers([self.non_owner], {"from": self.community_owner})
+        self.collectible.whitelistUsers([self.non_owner], {"from": self.owner})
 
         # assert non_owner is whitelisted
         assert self.collectible.isWhitelisted(self.non_owner) is True
 
         # Add non_owner_2 to whitelist
-        self.collectible.whitelistUsers([non_owner_2], {"from": self.community_owner})
+        self.collectible.whitelistUsers([non_owner_2], {"from": self.owner})
 
         # assert non_owner is whitelisted
         assert self.collectible.isWhitelisted(non_owner_2) is True


### PR DESCRIPTION
In discord, we've decided to trust the contract owner with all operations except setWithdrawAddress(), setDevAddresses(), and setGuilleAddress(); contract is coded to only withdraw to withdrawAddress. Changes and tests. 